### PR TITLE
Allow to provide a custom event class

### DIFF
--- a/lib/rails_event_store_active_record/event_repository.rb
+++ b/lib/rails_event_store_active_record/event_repository.rb
@@ -1,7 +1,7 @@
 module RailsEventStoreActiveRecord
   class EventRepository
-    def initialize
-      @adapter = ::RailsEventStoreActiveRecord::Event
+    def initialize(adapter: ::RailsEventStoreActiveRecord::Event)
+      @adapter = adapter
     end
     attr_reader :adapter
 

--- a/spec/event_repository_spec.rb
+++ b/spec/event_repository_spec.rb
@@ -4,5 +4,16 @@ require 'ruby_event_store/spec/event_repository_lint'
 module RailsEventStoreActiveRecord
   describe EventRepository do
     it_behaves_like :event_repository, EventRepository
+
+    specify 'initialize with adapter' do
+      repository = EventRepository.new
+      expect(repository.adapter).to eq(Event)
+    end
+
+    specify 'provide own event implementation' do
+      CustomEvent = Class.new(ActiveRecord::Base)
+      repository = EventRepository.new(adapter: CustomEvent)
+      expect(repository.adapter).to eq(CustomEvent)
+    end
   end
 end


### PR DESCRIPTION
Currently RailsEventStoreActiveRecord::Event assumes
that the underling table is named event_store_events
and that `data` and `metadata` are serialized with
the default serializer.

This commit allows to provide own implementation Event
with custom table name and serialization.