### PR TITLE
Rename migration generator from 'migrate' to 'migration'

### DIFF
--- a/lib/rails_event_store_active_record.rb
+++ b/lib/rails_event_store_active_record.rb
@@ -1,7 +1,6 @@
 require 'ruby_event_store'
 require 'active_record'
-require 'rails_event_store_active_record/generators/migrate_generator'
-require 'rails_event_store_active_record/generators/templates/migration_template'
+require 'rails_event_store_active_record/generators/migration_generator'
 require 'rails_event_store_active_record/event'
 require 'rails_event_store_active_record/event_repository'
 require 'rails_event_store_active_record/version'

--- a/lib/rails_event_store_active_record/generators/migration_generator.rb
+++ b/lib/rails_event_store_active_record/generators/migration_generator.rb
@@ -1,11 +1,11 @@
 require 'rails/generators'
 
 module RailsEventStoreActiveRecord
-  class MigrateGenerator < Rails::Generators::Base
+  class MigrationGenerator < Rails::Generators::Base
     source_root File.expand_path(File.join(File.dirname(__FILE__), '../generators/templates'))
 
     def create_migration
-      template "migration_template.rb", "db/migrate/#{timestamp}_create_events_table.rb"
+      template "migration_template.rb", "db/migrate/#{timestamp}_create_event_store_events.rb"
     end
 
     private

--- a/lib/rails_event_store_active_record/generators/templates/migration_template.rb
+++ b/lib/rails_event_store_active_record/generators/templates/migration_template.rb
@@ -1,6 +1,5 @@
-class CreateEventsTable < ActiveRecord::Migration
-
-  def self.up
+class CreateEventStoreEvents < ActiveRecord::Migration
+  def change
     create_table(:event_store_events) do |t|
       t.string      :stream,      null: false
       t.string      :event_type,  null: false
@@ -11,9 +10,5 @@ class CreateEventsTable < ActiveRecord::Migration
     end
     add_index :event_store_events, :stream
     add_index :event_store_events, :event_id, unique: true
-  end
-
-  def self.down
-    drop_table :event_store_events
   end
 end


### PR DESCRIPTION
Previous:
```ruby
  rails g rails_event_store_active_record:migrate
```

Current:
```ruby
  rails g rails_event_store_active_record:migration
```

In Rails the convention is to run `rails g migration` rather than `rails g migrate`

Other than that it provides a few minor fixes
* do not require migration_template.rb. Otherwise, it adds migration name to
  the global namesapce.
* Use shorter syntax in migration ("change" rather than "up/down")
* Migration name is the same as the name of the table