### PR TITLE
Index commonly searched fields: time and type.

### DIFF
--- a/lib/rails_event_store_active_record/generators/templates/migration_template.rb
+++ b/lib/rails_event_store_active_record/generators/templates/migration_template.rb
@@ -9,6 +9,8 @@ class CreateEventStoreEvents < ActiveRecord::Migration
       t.datetime    :created_at,  null: false
     end
     add_index :event_store_events, :stream
+    add_index :event_store_events, :created_at
+    add_index :event_store_events, :event_type
     add_index :event_store_events, :event_id, unique: true
   end
 end


### PR DESCRIPTION
* while working on another event store implementation it has proven very
  useful (and frequent) to filter by time and type of events recorded in
  store
* however there are no methods in EventRepository that would currently
  benefit from this change

What do you think?