### PR TITLE
Changes needed for https://github.com/arkency/rails_event_store/pull/61

### DIFF
--- a/lib/rails_event_store_active_record.rb
+++ b/lib/rails_event_store_active_record.rb
@@ -1,5 +1,3 @@
-require 'ruby_event_store'
-require 'active_record'
 require 'rails_event_store_active_record/generators/migration_generator'
 require 'rails_event_store_active_record/event'
 require 'rails_event_store_active_record/event_repository'

--- a/rails_event_store_active_record.gemspec
+++ b/rails_event_store_active_record.gemspec
@@ -25,10 +25,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'rails', '~> 4.2'
   spec.add_development_dependency 'sqlite3'
+  spec.add_development_dependency 'mutant-rspec', '~> 0.8.11'
 
   spec.add_dependency 'ruby_event_store', '~> 0.13.0'
   spec.add_dependency 'activesupport', '>= 3.0'
   spec.add_dependency 'activemodel', '>= 3.0'
-  spec.add_development_dependency 'mutant-rspec', '~> 0.8.11'
-
 end

--- a/spec/event_repository_spec.rb
+++ b/spec/event_repository_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'ruby_event_store'
 require 'ruby_event_store/spec/event_repository_lint'
 
 module RailsEventStoreActiveRecord


### PR DESCRIPTION
* `ruby_event_store` is only required in specs on this gem
* `active_record` is only required in `event.rb`